### PR TITLE
Fix the CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ find_package(date CONFIG REQUIRED)
 # Catch
 find_package(Catch2 CONFIG REQUIRED)
 
-find_package(BOOST REQUIRED)
+find_package(Boost REQUIRED)
 
 find_package(Eigen3 CONFIG REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,7 @@ target_link_libraries(cdt-opt
                               date::date
                               Catch2::Catch2
                               Eigen3::Eigen
-                              ${cgal_lib}
-                              CGAL::${cgal_lib}
-                              CGAL_Qt5_moc_and_resources
-                              CGAL::Qt5_moc_and_resources)
+                              CGAL::CGAL)
 target_compile_features(cdt-opt PRIVATE cxx_std_17)
 
 # Tests


### PR DESCRIPTION
In `CMakeLists.txt`:
- Fix the search for Boost, and
- fix the link to CGAL.
